### PR TITLE
Rewrote parts of the guide

### DIFF
--- a/content/desktop/adding-and-cloning-repositories/adding-an-existing-project-to-github-using-github-desktop.md
+++ b/content/desktop/adding-and-cloning-repositories/adding-an-existing-project-to-github-using-github-desktop.md
@@ -13,8 +13,8 @@ shortTitle: Add an existing project
 {% data reusables.git.remove-git-remote %}
 1. [Add the repository to GitHub Desktop](/desktop/adding-and-cloning-repositories/adding-a-repository-from-your-local-computer-to-github-desktop).
 {% data reusables.desktop.publish-repository %}
-1. In the "Publish Repository" window, in the "Name" field, type the desired name of the repository or use the default current local repository name.
+1. In the ‘Publish Repository’ window, type a name for your repository in the ‘Name’ field. You can either choose a custom name or use the default name, which is based on your current project folder.
 1. Optionally, add a description for the repository.
-1. Optionally, to publish a public repository, deselect **Keep this code private**.
+1. If you want to make your project accessible to everyone on GitHub, deselect **Keep this code private**. This will make your code visible to the public. Otherwise, leave this option selected to keep your project private.
 1. Select the "Organization" dropdown menu, then either click the organization where you want to publish the repository, or, to publish the repository to your personal account, click **None**.
 1. Click **Publish Repository**.


### PR DESCRIPTION
## Staging

Original move:
> 'In the ‘Publish Repository’ window, in the ‘Name’ field, type the desired name of the repository or use the default current local repository name.'

Revision: 
>' In the ‘Publish Repository’ window, type a name for your repository in the ‘Name’ field. You can either choose a custom name or use the default name, which is based on your current project folder.'

### Writing for intended audience 
Simplifies the language to make it clearer and more accessible.

### Presented info from users' point of view
Addresses the user directly with “type a name for your repository,” making the instruction feel more personal and relevant.

### Focus on users' goals
Helps the user understand the purpose of naming the repository, which is to identify it on GitHub.

- Practical reasons for supporting information
- Provides clear, step-by-step instruction
 
## Coaching

**Comment**: There are no images in this guide. I beleive it will help the users, who are novices, understand a lot better if they can visualize the actions they're carrying out.

- Writing for intended audience
- Presented info from users' point of view
- Focus on users' goals
- Practical reasons for supporting information
- Provides clear, step-by-step instruction

## Alerting

Original Move:

> 'Optionally, to publish a public repository, deselect Keep this code private.'

Revision:

> 'If you want to make your project accessible to everyone on GitHub, deselect Keep this code private. This will make your code visible to the public. Otherwise, leave this option selected to keep your project private.'

### Writing for intended audience
Clearly explains the implications of making the repository public vs. private, which is important for beginners and advanced users alike.

### Presented info from users' point of view
Uses “if you want to make your project accessible,” directly addressing user decision-making.

### Focus on users' goals
Guides users to make an informed decision based on their preference for visibility and privacy.

### Practical reasons for supporting information
Provides the practical implications of the action (public access vs. private), helping users understand the impact of their choice.

@braydenmarsh @civplayer please go ahead and review